### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/services_service/routes.py
+++ b/services_service/routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify
 from models import db, Service
-
+import logging
 services_bp = Blueprint('services', __name__)
 
 @services_bp.route('/services', methods=['POST'])
@@ -49,7 +49,8 @@ def create_service():
         db.session.commit()
         return jsonify(new_service.to_dict()), 201
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        logging.error("Error creating service: %s", e)
+        return jsonify({'error': 'An internal error has occurred!'}), 400
 
 @services_bp.route('/services', methods=['GET'])
 def get_services():
@@ -113,7 +114,8 @@ def update_service(id):
         db.session.commit()
         return jsonify(service.to_dict()), 200
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        logging.error("Error updating service: %s", e)
+        return jsonify({'error': 'An internal error has occurred!'}), 400
 
 @services_bp.route('/services/<int:id>', methods=['DELETE'])
 def delete_service(id):


### PR DESCRIPTION
Fixes [https://github.com/NightCrawler96/remote-scanner/security/code-scanning/4](https://github.com/NightCrawler96/remote-scanner/security/code-scanning/4)

To fix the problem, we need to ensure that detailed exception information is not exposed to the user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by using a logging mechanism to log the exception details and then returning a generic error message in the response.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the return statement in the exception handling block to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
