### PR TITLE
Fix code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/vulns_service/routes.py
+++ b/vulns_service/routes.py
@@ -1,5 +1,7 @@
+import logging
 from flask import Blueprint, request, jsonify
 from models import db, Vulnerability
+
 
 vulns_bp = Blueprint('vulnerabilities', __name__)
 
@@ -49,7 +51,8 @@ def create_vulnerability():
         db.session.commit()
         return jsonify(new_vuln.to_dict()), 201
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        logging.error("Error creating vulnerability: %s", e, exc_info=True)
+        return jsonify({'error': 'An internal error has occurred!'}), 400
 
 @vulns_bp.route('/vulnerabilities', methods=['GET'])
 def get_vulnerabilities():
@@ -113,7 +116,8 @@ def update_vulnerability(id):
         db.session.commit()
         return jsonify(vuln.to_dict()), 200
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        logging.error("Error updating vulnerability: %s", e, exc_info=True)
+        return jsonify({'error': 'An internal error has occurred!'}), 400
 
 @vulns_bp.route('/vulnerabilities/<int:id>', methods=['DELETE'])
 def delete_vulnerability(id):


### PR DESCRIPTION
Fixes [https://github.com/NightCrawler96/remote-scanner/security/code-scanning/6](https://github.com/NightCrawler96/remote-scanner/security/code-scanning/6)

To fix the problem, we need to ensure that detailed error information is logged on the server side while returning a generic error message to the user. This can be achieved by using Python's logging module to log the exception details and modifying the response to return a generic error message.

- Add an import for the logging module.
- Configure the logging module to log error messages.
- Replace the current exception handling code to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
