### PR TITLE
Fix code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/targets_service/routes.py
+++ b/targets_service/routes.py
@@ -1,6 +1,8 @@
+import logging
 from flask import Blueprint, request, jsonify
 from models import db, Target
 
+logging.basicConfig(level=logging.ERROR)
 targets_bp = Blueprint('targets', __name__)
 
 @targets_bp.route('/targets', methods=['POST'])
@@ -43,7 +45,8 @@ def create_target():
         db.session.commit()
         return jsonify(new_target.to_dict()), 201
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        logging.error("Error creating target: %s", e, exc_info=True)
+        return jsonify({'error': 'An internal error has occurred.'}), 400
 
 @targets_bp.route('/targets', methods=['GET'])
 def get_targets():
@@ -107,7 +110,8 @@ def update_target(id):
         db.session.commit()
         return jsonify(target.to_dict()), 200
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        logging.error("Error updating target: %s", e, exc_info=True)
+        return jsonify({'error': 'An internal error has occurred.'}), 400
 
 @targets_bp.route('/targets/<int:id>', methods=['DELETE'])
 def delete_target(id):


### PR DESCRIPTION
Fixes [https://github.com/NightCrawler96/remote-scanner/security/code-scanning/2](https://github.com/NightCrawler96/remote-scanner/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the client. This can be achieved by using Python's logging module to log the exception details and returning a generic error message in the response.

1. Import the `logging` module.
2. Configure the logging settings if not already configured.
3. Replace the line that returns the exception message with a line that logs the exception and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
